### PR TITLE
adding gitignore that removes compiled python binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]


### PR DESCRIPTION
hit this as soon as i packaged the modules for use in notebooks